### PR TITLE
client connect and disconnect queue

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,10 +25,10 @@ func main() {
 	udpPort := "8889"
 
 	clientManager := clients.NewClientManager()
-	messageQueue := queue.NewInMemoryQueue()
+	clientMessageQueue := queue.NewInMemoryQueue()
 
-	tcpServer := servers.NewTCPServer(clientManager, messageQueue, tcpPort)
-	udpServer := servers.NewUDPServer(clientManager, messageQueue, udpPort)
+	tcpServer := servers.NewTCPServer(clientManager, clientMessageQueue, tcpPort)
+	udpServer := servers.NewUDPServer(clientManager, clientMessageQueue, udpPort)
 	go tcpServer.Start()
 	go udpServer.Start()
 
@@ -39,17 +39,17 @@ func main() {
 	repository := repositories.NewPostgresRepository(ctx, connStr)
 	defer repository.Close(ctx)
 
-	stateManager := state.NewInMemoryStateManager()
-
 	gameLoopInterval := 100 * time.Millisecond // 10 FPS
 	saveLoopInterval := 5 * time.Second
 	gameManager := game.NewGameManager(game.NewGameManagerOptions{
-		ClientManager:    clientManager,
-		MessageQueue:     messageQueue,
-		Repository:       repository,
-		StateManager:     stateManager,
-		GameLoopInterval: gameLoopInterval,
-		SaveLoopInterval: saveLoopInterval,
+		ClientManager:              clientManager,
+		ClientMessageQueue:         clientMessageQueue,
+		ClientConnectEventQueue:    queue.NewInMemoryQueue(),
+		ClientDisconnectEventQueue: queue.NewInMemoryQueue(),
+		Repository:                 repository,
+		StateManager:               state.NewInMemoryStateManager(),
+		GameLoopInterval:           gameLoopInterval,
+		SaveLoopInterval:           saveLoopInterval,
 	})
 
 	fmt.Println("Starting game manager")

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -132,14 +132,10 @@ func (cm *ClientManager) generateUniqueID(maxRetries int) (uint32, error) {
 	return 0, fmt.Errorf("failed to generate a unique ID after %d attempts", maxRetries)
 }
 
-// RegisterConnectHandler registers a handler for client connect events.
-// The handler will be called in a goroutine.
 func (cm *ClientManager) RegisterConnectHandler(handler ClientEventHandler) {
 	cm.connectEventManager.RegisterHandler(handler)
 }
 
-// RegisterDisconnectHandler registers a handler for client disconnect events.
-// The handler will be called in a goroutine.
 func (cm *ClientManager) RegisterDisconnectHandler(handler ClientEventHandler) {
 	cm.disconnectEventManager.RegisterHandler(handler)
 }

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -24,14 +24,18 @@ type ClientManager struct {
 	clientsLock sync.RWMutex
 	nextID      uint32
 	// UDP connection for broadcasting to clients
-	udpConn *net.UDPConn
+	udpConn                *net.UDPConn
+	connectEventManager    *ClientEventManager
+	disconnectEventManager *ClientEventManager
 }
 
 // NewClientManager creates a new ClientManager
 func NewClientManager() *ClientManager {
 	return &ClientManager{
-		clients: make(map[uint32]*Client),
-		nextID:  1,
+		clients:                make(map[uint32]*Client),
+		nextID:                 1,
+		connectEventManager:    NewClientEventManager(),
+		disconnectEventManager: NewClientEventManager(),
 	}
 }
 
@@ -48,13 +52,22 @@ func (cm *ClientManager) GetUDPConn() *net.UDPConn {
 	return cm.udpConn
 }
 
-// GetClients returns a list of all connected clients
+// GetClients returns a slice with a copy of all connected clients.
 func (cm *ClientManager) GetClients() []*Client {
 	cm.clientsLock.RLock()
 	defer cm.clientsLock.RUnlock()
 	clients := make([]*Client, 0, len(cm.clients))
 	for _, client := range cm.clients {
-		clients = append(clients, client)
+		copy := &Client{
+			ID:      client.ID,
+			TCPConn: client.TCPConn,
+			UDPAddress: &net.UDPAddr{
+				IP:   client.UDPAddress.IP,
+				Port: client.UDPAddress.Port,
+				Zone: client.UDPAddress.Zone,
+			},
+		}
+		clients = append(clients, copy)
 	}
 	return clients
 }
@@ -63,7 +76,7 @@ func (cm *ClientManager) GetClients() []*Client {
 func (cm *ClientManager) AddClient(tcpConn net.Conn) (uint32, error) {
 	cm.clientsLock.Lock()
 	defer cm.clientsLock.Unlock()
-	clientID, err := cm.GenerateUniqueID(ClientIDMaxRetries)
+	clientID, err := cm.generateUniqueID(ClientIDMaxRetries)
 	if err != nil {
 		return 0, fmt.Errorf("failed to generate a unique ID: %v", err)
 	}
@@ -72,6 +85,7 @@ func (cm *ClientManager) AddClient(tcpConn net.Conn) (uint32, error) {
 		TCPConn: tcpConn,
 	}
 	cm.clients[clientID] = client
+	cm.connectEventManager.Trigger(ClientEvent{ClientID: clientID})
 	return clientID, nil
 }
 
@@ -79,6 +93,7 @@ func (cm *ClientManager) AddClient(tcpConn net.Conn) (uint32, error) {
 func (cm *ClientManager) RemoveClient(clientID uint32) {
 	cm.clientsLock.Lock()
 	defer cm.clientsLock.Unlock()
+	cm.disconnectEventManager.Trigger(ClientEvent{ClientID: clientID})
 	delete(cm.clients, clientID)
 }
 
@@ -95,20 +110,6 @@ func (cm *ClientManager) SetUDPAddress(clientID uint32, addr *net.UDPAddr) {
 	cm.clients[clientID].UDPAddress = addr
 }
 
-// GetUDPAddress retrieves the UDP address of a client
-func (cm *ClientManager) GetUDPAddress(clientID uint32) *net.UDPAddr {
-	cm.clientsLock.RLock()
-	defer cm.clientsLock.RUnlock()
-	return cm.clients[clientID].UDPAddress
-}
-
-// GetClientByID retrieves a client by its ID
-func (cm *ClientManager) GetClientByID(clientID uint32) *Client {
-	cm.clientsLock.RLock()
-	defer cm.clientsLock.RUnlock()
-	return cm.clients[clientID]
-}
-
 func (cm *ClientManager) Exists(clientID uint32) bool {
 	cm.clientsLock.RLock()
 	defer cm.clientsLock.RUnlock()
@@ -116,9 +117,9 @@ func (cm *ClientManager) Exists(clientID uint32) bool {
 	return ok
 }
 
-// GenerateUniqueID generates a unique client ID with a maximum number of retries
+// generateUniqueID generates a unique client ID with a maximum number of retries
 // it reads from the clients, so it needs to be locked before calling
-func (cm *ClientManager) GenerateUniqueID(maxRetries int) (uint32, error) {
+func (cm *ClientManager) generateUniqueID(maxRetries int) (uint32, error) {
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		id := cm.nextID
 		if _, ok := cm.clients[id]; !ok {
@@ -129,4 +130,16 @@ func (cm *ClientManager) GenerateUniqueID(maxRetries int) (uint32, error) {
 	}
 
 	return 0, fmt.Errorf("failed to generate a unique ID after %d attempts", maxRetries)
+}
+
+// RegisterConnectHandler registers a handler for client connect events.
+// The handler will be called in a goroutine.
+func (cm *ClientManager) RegisterConnectHandler(handler ClientEventHandler) {
+	cm.connectEventManager.RegisterHandler(handler)
+}
+
+// RegisterDisconnectHandler registers a handler for client disconnect events.
+// The handler will be called in a goroutine.
+func (cm *ClientManager) RegisterDisconnectHandler(handler ClientEventHandler) {
+	cm.disconnectEventManager.RegisterHandler(handler)
 }

--- a/pkg/clients/events.go
+++ b/pkg/clients/events.go
@@ -1,0 +1,38 @@
+package clients
+
+import (
+	"sync"
+)
+
+type ClientEvent struct {
+	ClientID uint32
+}
+
+type ClientEventHandler func(event ClientEvent)
+
+type ClientEventManager struct {
+	lock     sync.Mutex
+	handlers []ClientEventHandler
+}
+
+func NewClientEventManager() *ClientEventManager {
+	return &ClientEventManager{}
+}
+
+// RegisterHandler registers a handler for events.
+// The handler will be called in a goroutine.
+func (em *ClientEventManager) RegisterHandler(handler ClientEventHandler) {
+	em.lock.Lock()
+	defer em.lock.Unlock()
+	em.handlers = append(em.handlers, handler)
+}
+
+// Trigger triggers an event.
+// All registered handlers will be called their own goroutine.
+func (em *ClientEventManager) Trigger(event ClientEvent) {
+	em.lock.Lock()
+	defer em.lock.Unlock()
+	for _, handler := range em.handlers {
+		go handler(event)
+	}
+}

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -68,8 +68,7 @@ func (gm *GameManager) Stop() {
 
 func (gm *GameManager) onClientConnect(event clients.ClientEvent) {
 	var playerState *types.PlayerState
-	lastKnownState, err := gm.repository.LoadPlayerState(context.Background(), event.ClientID)
-	if err == nil {
+	if lastKnownState, err := gm.repository.LoadPlayerState(context.Background(), event.ClientID); err == nil {
 		playerState = lastKnownState
 	} else {
 		if !repositories.IsNotFound(err) {

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -16,36 +16,46 @@ import (
 )
 
 type GameManager struct {
-	clientManager    *clients.ClientManager
-	messageQueue     *queue.InMemoryQueue
-	repository       repositories.Repository
-	stateManager     state.StateManager
-	gameLoopInterval time.Duration
-	saveLoopInterval time.Duration
+	clientManager          *clients.ClientManager
+	clientMessageQueue     queue.Queue
+	addPlayerEventQueue    queue.Queue
+	removePlayerEventQueue queue.Queue
+	repository             repositories.Repository
+	stateManager           state.StateManager
+	gameLoopInterval       time.Duration
+	saveLoopInterval       time.Duration
 }
 
 // NewGameManagerOptions contains options for creating a new GameManager.
 type NewGameManagerOptions struct {
-	ClientManager    *clients.ClientManager
-	MessageQueue     *queue.InMemoryQueue
-	Repository       repositories.Repository
-	StateManager     state.StateManager
-	GameLoopInterval time.Duration
-	SaveLoopInterval time.Duration
+	ClientManager              *clients.ClientManager
+	ClientMessageQueue         queue.Queue
+	ClientConnectEventQueue    queue.Queue
+	ClientDisconnectEventQueue queue.Queue
+	Repository                 repositories.Repository
+	StateManager               state.StateManager
+	GameLoopInterval           time.Duration
+	SaveLoopInterval           time.Duration
 }
 
 func NewGameManager(opts NewGameManagerOptions) *GameManager {
 	return &GameManager{
-		clientManager:    opts.ClientManager,
-		messageQueue:     opts.MessageQueue,
-		repository:       opts.Repository,
-		stateManager:     opts.StateManager,
-		gameLoopInterval: opts.GameLoopInterval,
-		saveLoopInterval: opts.SaveLoopInterval,
+		clientManager:          opts.ClientManager,
+		clientMessageQueue:     opts.ClientMessageQueue,
+		addPlayerEventQueue:    opts.ClientConnectEventQueue,
+		removePlayerEventQueue: opts.ClientDisconnectEventQueue,
+		repository:             opts.Repository,
+		stateManager:           opts.StateManager,
+		gameLoopInterval:       opts.GameLoopInterval,
+		saveLoopInterval:       opts.SaveLoopInterval,
 	}
 }
 
 func (gm *GameManager) Start(ctx context.Context) {
+	// register client connect/disconnect handlers
+	gm.clientManager.RegisterConnectHandler(gm.onClientConnect)
+	gm.clientManager.RegisterDisconnectHandler(gm.onClientDisconnect)
+
 	// Save loop runs in the background
 	go gm.saveLoop(ctx)
 	// Game loop runs in the foreground
@@ -54,6 +64,36 @@ func (gm *GameManager) Start(ctx context.Context) {
 
 func (gm *GameManager) Stop() {
 	// TODO: gracefully stop the game and save the game state
+}
+
+func (gm *GameManager) onClientConnect(event clients.ClientEvent) {
+	var playerState *types.PlayerState
+	lastKnownState, err := gm.repository.LoadPlayerState(context.Background(), event.ClientID)
+	if err == nil {
+		playerState = lastKnownState
+	} else {
+		if repositories.IsNotFound(err) {
+			fmt.Printf("Error: failed to get player state for client %d: %v\n", event.ClientID, err)
+		}
+		fmt.Printf("Adding client %d with default values\n", event.ClientID)
+		playerState = &types.PlayerState{
+			P: types.Position{
+				X: 0,
+				Y: 0,
+			},
+		}
+	}
+
+	gm.addPlayerEventQueue.Enqueue(&types.AddPlayerEvent{
+		ClientID:    event.ClientID,
+		PlayerState: playerState,
+	})
+}
+
+func (gm *GameManager) onClientDisconnect(event clients.ClientEvent) {
+	gm.removePlayerEventQueue.Enqueue(&types.RemovePlayerEvent{
+		ClientID: event.ClientID,
+	})
 }
 
 // gameLoop starts a loop that runs the game logic.
@@ -82,11 +122,10 @@ func (gm *GameManager) gameTick(ctx context.Context, t time.Time) error {
 	}
 
 	gameState.Timestamp = t.UnixMilli()
-	clients := gm.clientManager.GetClients()
-	gm.addConnectedPlayers(ctx, clients, gameState)
-	gm.processMessages(gameState)
-	gm.removeDisconnectedPlayers(ctx, gameState)
-	gm.broadcastGameState(clients, gameState)
+	gm.processAddPlayerEvents(gameState)
+	gm.processClientMessages(gameState)
+	gm.processRemovePlayerEvents(gameState)
+	gm.broadcastGameState(gameState)
 
 	if err := gm.stateManager.Set(gameState); err != nil {
 		return fmt.Errorf("failed to set game state: %v", err)
@@ -95,31 +134,24 @@ func (gm *GameManager) gameTick(ctx context.Context, t time.Time) error {
 	return nil
 }
 
-// addConnectedPlayers adds connected clients to the game state.
-func (gm *GameManager) addConnectedPlayers(ctx context.Context, clients []*clients.Client, gameState *types.GameState) {
-	for _, client := range clients {
-		if _, ok := gameState.Players[client.ID]; !ok {
-			lastKnownState, err := gm.repository.LoadPlayerState(ctx, client.ID)
-			if err == nil {
-				gameState.Players[client.ID] = lastKnownState
-			} else {
-				fmt.Printf("Error: failed to get player state for client %d: %v\n", client.ID, err)
-				fmt.Printf("Adding client %d to game state with default values\n", client.ID)
-				gameState.Players[client.ID] = &types.PlayerState{
-					P: types.Position{
-						X: 0,
-						Y: 0,
-					},
-				}
-			}
+// processAddPlayerEvents processes all pending add player events.
+func (gm *GameManager) processAddPlayerEvents(gameState *types.GameState) {
+	pendingEvents := gm.addPlayerEventQueue.ReadAllMessages()
+	for _, item := range pendingEvents {
+		event, ok := item.(*types.AddPlayerEvent)
+		if !ok {
+			fmt.Println("Error: failed to cast message to types.AddPlayerEvent")
+			continue
 		}
+
+		gameState.Players[event.ClientID] = event.PlayerState
 	}
 }
 
-// processMessages processes all pending messages in the queue
+// processClientMessages processes all pending messages in the queue
 // and updates the game state accordingly.
-func (gm *GameManager) processMessages(gameState *types.GameState) {
-	pendingMessages := gm.messageQueue.ReadAllMessages()
+func (gm *GameManager) processClientMessages(gameState *types.GameState) {
+	pendingMessages := gm.clientMessageQueue.ReadAllMessages()
 	for _, item := range pendingMessages {
 		message, ok := item.(*messages.Message)
 		if !ok {
@@ -143,29 +175,29 @@ func (gm *GameManager) processMessages(gameState *types.GameState) {
 	}
 }
 
-// removeDisconnectedPlayers removes disconnected clients from the game state.
-func (gm *GameManager) removeDisconnectedPlayers(ctx context.Context, gameState *types.GameState) {
-	for clientID, playerState := range gameState.Players {
-		if !gm.clientManager.Exists(clientID) {
-			if err := gm.repository.SavePlayerState(ctx, gameState.Timestamp, clientID, playerState); err != nil {
-				fmt.Printf("Error: failed to save player state for client %d: %v\n", clientID, err)
-				// don't delete the player from the game state if we can't save their state
-				continue
-			}
-			delete(gameState.Players, clientID)
+// processRemovePlayerEvents removes players from the game state.
+func (gm *GameManager) processRemovePlayerEvents(gameState *types.GameState) {
+	pendingEvents := gm.removePlayerEventQueue.ReadAllMessages()
+	for _, item := range pendingEvents {
+		event, ok := item.(*types.RemovePlayerEvent)
+		if !ok {
+			fmt.Println("Error: failed to cast message to types.RemovePlayerEvent")
+			continue
 		}
+
+		delete(gameState.Players, event.ClientID)
 	}
 }
 
 // broadcastGameState sends the game state to connected clients.
-func (gm *GameManager) broadcastGameState(clients []*clients.Client, gameState *types.GameState) {
+func (gm *GameManager) broadcastGameState(gameState *types.GameState) {
 	payload, err := json.Marshal(gameState)
 	if err != nil {
 		fmt.Printf("Error: failed to marshal game state: %v\n", err)
 		return
 	}
 
-	for _, client := range clients {
+	for _, client := range gm.clientManager.GetClients() {
 		message := &messages.Message{
 			ClientID: 0, // ClientID 0 means the message is from the server
 			Type:     messages.MessageTypeServerGameUpdate,
@@ -181,9 +213,11 @@ func (gm *GameManager) broadcastGameState(clients []*clients.Client, gameState *
 		err := servers.WriteMessageToUDP(gm.clientManager.GetUDPConn(), client.UDPAddress, message)
 		if err != nil {
 			fmt.Printf("Error: failed to write message to UDP connection for client %d: %v\n", client.ID, err)
-		} else {
-			fmt.Printf("Sent message: %s\n", message.Type)
+			continue
 		}
+
+		// TODO: trace logging for stuff like this
+		// fmt.Printf("Sent message: %s\n", message.Type)
 	}
 }
 

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -72,7 +72,7 @@ func (gm *GameManager) onClientConnect(event clients.ClientEvent) {
 	if err == nil {
 		playerState = lastKnownState
 	} else {
-		if repositories.IsNotFound(err) {
+		if !repositories.IsNotFound(err) {
 			fmt.Printf("Error: failed to get player state for client %d: %v\n", event.ClientID, err)
 		}
 		fmt.Printf("Adding client %d with default values\n", event.ClientID)

--- a/pkg/game/types/types.go
+++ b/pkg/game/types/types.go
@@ -15,3 +15,12 @@ type Position struct {
 	X float64 `json:"x"`
 	Y float64 `json:"y"`
 }
+
+type AddPlayerEvent struct {
+	ClientID    uint32
+	PlayerState *PlayerState
+}
+
+type RemovePlayerEvent struct {
+	ClientID uint32
+}

--- a/pkg/repositories/postgres.go
+++ b/pkg/repositories/postgres.go
@@ -114,6 +114,9 @@ func (r *PostgresRepository) LoadPlayerState(ctx context.Context, clientID uint3
 	var x float64
 	var y float64
 	if err := r.conn.QueryRow(ctx, q, clientID).Scan(&x, &y); err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, &ErrNotFound{}
+		}
 		return nil, fmt.Errorf("failed to scan player: %v", err)
 	}
 

--- a/pkg/repositories/types.go
+++ b/pkg/repositories/types.go
@@ -1,0 +1,13 @@
+package repositories
+
+type ErrNotFound struct {
+}
+
+func (e *ErrNotFound) Error() string {
+	return "not found"
+}
+
+func IsNotFound(err error) bool {
+	_, ok := err.(*ErrNotFound)
+	return ok
+}

--- a/pkg/state/memory.go
+++ b/pkg/state/memory.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"sync"
 
 	gametypes "github.com/cbodonnell/flywheel/pkg/game/types"
@@ -22,6 +23,7 @@ func NewInMemoryStateManager() *InMemoryStateManager {
 func (m *InMemoryStateManager) Get() (*gametypes.GameState, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
+	// TODO: assess usage of pointers here and whether values might be better
 	copy := &gametypes.GameState{
 		Players: make(map[uint32]*gametypes.PlayerState),
 	}
@@ -40,6 +42,11 @@ func (m *InMemoryStateManager) Get() (*gametypes.GameState, error) {
 func (m *InMemoryStateManager) Set(gameState *gametypes.GameState) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
+	if gameState == nil {
+		return fmt.Errorf("game state is nil")
+	}
+
 	m.gameState = gameState
 	return nil
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -5,6 +5,7 @@ import (
 )
 
 // StateManager provides shared access to the game state.
+// Implementations must be thread-safe.
 type StateManager interface {
 	// Get returns a copy of the current game state.
 	Get() (*gametypes.GameState, error)


### PR DESCRIPTION
adds two additional queues to the game manager for processing client connect and disconnect events and applying the necessary updates to the game state (adding/removing the associated players). doing this removes all database calls (load/save player data) from the main thread so as not to block the game loop. it also alleviates the need to iterate over players and connected clients to check whether or not they need to be added or removed from the game state.