### PR TITLE
in memory queue as slice

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,7 +37,7 @@ func main() {
 	ctx := context.Background()
 
 	clientManager := clients.NewClientManager()
-	clientMessageQueue := queue.NewInMemoryQueue()
+	clientMessageQueue := queue.NewInMemoryQueue(10000)
 
 	tcpServer := servers.NewTCPServer(clientManager, clientMessageQueue, *tcpPort)
 	udpServer := servers.NewUDPServer(clientManager, clientMessageQueue, *udpPort)
@@ -51,7 +51,7 @@ func main() {
 	repository := repositories.NewPostgresRepository(ctx, connStr)
 	defer repository.Close(ctx)
 
-	connectionEventQueue := queue.NewInMemoryQueue()
+	connectionEventQueue := queue.NewInMemoryQueue(1000)
 
 	clientEventWorker := workers.NewClientEventWorker(workers.NewClientEventWorkerOptions{
 		ClientManager:        clientManager,

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -80,11 +80,13 @@ func (cm *ClientManager) GetClients() []*Client {
 		copy := &Client{
 			ID:      client.ID,
 			TCPConn: client.TCPConn,
-			UDPAddress: &net.UDPAddr{
+		}
+		if client.UDPAddress != nil {
+			copy.UDPAddress = &net.UDPAddr{
 				IP:   client.UDPAddress.IP,
 				Port: client.UDPAddress.Port,
 				Zone: client.UDPAddress.Zone,
-			},
+			}
 		}
 		clients = append(clients, copy)
 	}

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -94,7 +94,11 @@ func (gm *GameManager) gameTick(ctx context.Context, t time.Time) error {
 // processConnectionEvents processes all pending connection events in the queue
 // and updates the game state accordingly.
 func (gm *GameManager) processConnectionEvents(gameState *types.GameState) {
-	pendingEvents := gm.connectionEventQueue.ReadAllMessages()
+	pendingEvents, err := gm.connectionEventQueue.ReadAllMessages()
+	if err != nil {
+		log.Error("Failed to read connection events: %v", err)
+		return
+	}
 	for _, item := range pendingEvents {
 		switch event := item.(type) {
 		case *types.ConnectPlayerEvent:
@@ -117,7 +121,11 @@ func (gm *GameManager) processConnectionEvents(gameState *types.GameState) {
 // processClientMessages processes all pending client messages in the queue
 // and updates the game state accordingly.
 func (gm *GameManager) processClientMessages(gameState *types.GameState) {
-	pendingMessages := gm.clientMessageQueue.ReadAllMessages()
+	pendingMessages, err := gm.clientMessageQueue.ReadAllMessages()
+	if err != nil {
+		log.Error("Failed to read client messages: %v", err)
+		return
+	}
 	for _, item := range pendingMessages {
 		message, ok := item.(*messages.Message)
 		if !ok {

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -142,7 +142,7 @@ func (gm *GameManager) processClientMessages(gameState *types.GameState) {
 				continue
 			}
 			if _, ok := gameState.Players[message.ClientID]; !ok {
-				log.Error("Client %d does not have a player state", message.ClientID)
+				log.Warn("Client %d is not in the game state", message.ClientID)
 				continue
 			}
 			// TODO: validate the update before applying it

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -2,9 +2,14 @@ package queue
 
 // Queue represents a basic queue.
 type Queue interface {
-	Enqueue(item interface{})
-	Dequeue() interface{}
-	Size() int
-	ReadAllMessages() []interface{}
-	ClearQueue()
+	// Enqueue adds an item to the end of the queue.
+	Enqueue(item interface{}) error
+	// Dequeue removes and returns the item from the front of the queue.
+	Dequeue() (interface{}, error)
+	// Size returns the current size of the queue.
+	Size() (int, error)
+	// ReadAllMessages reads all pending messages in the queue
+	ReadAllMessages() ([]interface{}, error)
+	// ClearQueue clears all messages from the queue.
+	ClearQueue() error
 }

--- a/pkg/servers/tcp.go
+++ b/pkg/servers/tcp.go
@@ -14,12 +14,12 @@ import (
 // TCPServer represents a TCP server.
 type TCPServer struct {
 	ClientManager *clients.ClientManager
-	MessageQueue  *queue.InMemoryQueue
+	MessageQueue  queue.Queue
 	Port          string
 }
 
 // NewTCPServer creates a new TCP server.
-func NewTCPServer(clientManager *clients.ClientManager, messageQueue *queue.InMemoryQueue, port string) *TCPServer {
+func NewTCPServer(clientManager *clients.ClientManager, messageQueue queue.Queue, port string) *TCPServer {
 	return &TCPServer{
 		ClientManager: clientManager,
 		MessageQueue:  messageQueue,

--- a/pkg/servers/tcp.go
+++ b/pkg/servers/tcp.go
@@ -96,7 +96,9 @@ func (s *TCPServer) handleTCPConnection(conn net.Conn) {
 		log.Trace("Received TCP message of type %s from client %d", message.Type, message.ClientID)
 
 		// TODO: some messages might not make sense to queue for the game loop (e.g. a message to disconnect)
-		s.MessageQueue.Enqueue(message)
+		if err := s.MessageQueue.Enqueue(message); err != nil {
+			log.Error("Failed to enqueue message: %v", err)
+		}
 	}
 }
 

--- a/pkg/servers/udp.go
+++ b/pkg/servers/udp.go
@@ -74,7 +74,9 @@ func (s *UDPServer) Start() {
 				log.Error("Failed to send server pong: %v", err)
 			}
 		default:
-			s.MessageQueue.Enqueue(message)
+			if err := s.MessageQueue.Enqueue(message); err != nil {
+				log.Error("Failed to enqueue message: %v", err)
+			}
 		}
 	}
 }

--- a/pkg/servers/udp.go
+++ b/pkg/servers/udp.go
@@ -14,12 +14,12 @@ import (
 // UDPServer represents a UDP server.
 type UDPServer struct {
 	ClientManager *clients.ClientManager
-	MessageQueue  *queue.InMemoryQueue
+	MessageQueue  queue.Queue
 	Port          string
 }
 
 // NewUDPServer creates a new UDP server.
-func NewUDPServer(clientManager *clients.ClientManager, messageQueue *queue.InMemoryQueue, port string) *UDPServer {
+func NewUDPServer(clientManager *clients.ClientManager, messageQueue queue.Queue, port string) *UDPServer {
 	return &UDPServer{
 		ClientManager: clientManager,
 		MessageQueue:  messageQueue,

--- a/pkg/workers/events.go
+++ b/pkg/workers/events.go
@@ -64,14 +64,18 @@ func (w *ClientEventWorker) handleClientConnect(event clients.ClientEvent) {
 		}
 	}
 
-	w.connectionEventQueue.Enqueue(&gametypes.ConnectPlayerEvent{
+	if err := w.connectionEventQueue.Enqueue(&gametypes.ConnectPlayerEvent{
 		ClientID:    event.ClientID,
 		PlayerState: playerState,
-	})
+	}); err != nil {
+		log.Error("Failed to enqueue connect player event: %v", err)
+	}
 }
 
 func (w *ClientEventWorker) handleClientDisconnect(event clients.ClientEvent) {
-	w.connectionEventQueue.Enqueue(&gametypes.DisconnectPlayerEvent{
+	if err := w.connectionEventQueue.Enqueue(&gametypes.DisconnectPlayerEvent{
 		ClientID: event.ClientID,
-	})
+	}); err != nil {
+		log.Error("Failed to enqueue disconnect player event: %v", err)
+	}
 }


### PR DESCRIPTION
changes the in-memory queue implementation to use a slice to store items rather than a buffered channel. the buffered channel was not necessary as the implementation was already thread-safe because of the mutex