### PR TITLE
server reconciliation

### DIFF
--- a/client/objects/player.go
+++ b/client/objects/player.go
@@ -144,7 +144,7 @@ func (p *Player) Draw(screen *ebiten.Image) {
 // the client state for that timestamp matches the server state.
 // If it doesn't match, the server state is applied and all of the
 // past updates that are after the last processed timestamp are replayed.
-func (p *Player) ReconcileState(state *gametypes.PlayerState) {
+func (p *Player) ReconcileState(state *gametypes.PlayerState) error {
 	foundPreviousState := false
 	for i := len(p.previousStates) - 1; i >= 0; i-- {
 		ps := p.previousStates[i]
@@ -173,6 +173,8 @@ func (p *Player) ReconcileState(state *gametypes.PlayerState) {
 	}
 
 	if !foundPreviousState {
-		log.Warn("Failed to find previous state at timestamp %d for %s for reconciliation", state.LastProcessedTimestamp, p.ID)
+		return fmt.Errorf("failed to find previous state for timestamp %d", state.LastProcessedTimestamp)
 	}
+
+	return nil
 }

--- a/client/objects/player.go
+++ b/client/objects/player.go
@@ -10,9 +10,15 @@ import (
 	"github.com/cbodonnell/flywheel/pkg/game"
 	"github.com/cbodonnell/flywheel/pkg/game/constants"
 	gametypes "github.com/cbodonnell/flywheel/pkg/game/types"
+	"github.com/cbodonnell/flywheel/pkg/log"
 	"github.com/cbodonnell/flywheel/pkg/messages"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+const (
+	// MaxPreviousStates is the maximum number of past states to keep
+	MaxPreviousStates = 60
 )
 
 type Player struct {
@@ -20,7 +26,15 @@ type Player struct {
 	// TODO: should this be the network manager or the parent game object?
 	networkManager *network.NetworkManager
 	isLocalPlayer  bool
+	// TODO: make this private with a getter and setter
 	State          *gametypes.PlayerState
+	previousStates []PreviousState
+	pastUpdates    []*messages.ClientPlayerUpdate
+}
+
+type PreviousState struct {
+	Timestamp int64
+	State     *gametypes.PlayerState
 }
 
 func NewPlayer(id string, networkManager *network.NetworkManager, state *gametypes.PlayerState) (*Player, error) {
@@ -66,11 +80,12 @@ func (p *Player) Update() error {
 	inputJump := ebiten.IsKeyPressed(ebiten.KeySpace)
 
 	cpu := &messages.ClientPlayerUpdate{
-		Timestamp: time.Now().UnixMilli(),
-		InputX:    inputX,
-		InputY:    inputY,
-		InputJump: inputJump,
-		DeltaTime: 1.0 / float64(ebiten.TPS()),
+		Timestamp:   time.Now().UnixMilli(),
+		InputX:      inputX,
+		InputY:      inputY,
+		InputJump:   inputJump,
+		DeltaTime:   1.0 / float64(ebiten.TPS()),
+		PastUpdates: p.pastUpdates,
 	}
 	payload, err := json.Marshal(cpu)
 	if err != nil {
@@ -87,7 +102,21 @@ func (p *Player) Update() error {
 		return fmt.Errorf("failed to send client player update: %v", err)
 	}
 
-	game.UpdatePlayerState(p.State, cpu)
+	cpu.PastUpdates = nil // clear the past updates after sending the message
+	p.pastUpdates = append(p.pastUpdates, cpu)
+	for len(p.pastUpdates) > messages.MaxPreviousUpdates {
+		p.pastUpdates = p.pastUpdates[1:]
+	}
+
+	game.ApplyInput(p.State, cpu)
+
+	p.previousStates = append(p.previousStates, PreviousState{
+		Timestamp: cpu.Timestamp,
+		State:     p.State.Copy(), // store a copy as the state will be modified by the game loop
+	})
+	for len(p.previousStates) > MaxPreviousStates {
+		p.previousStates = p.previousStates[1:]
+	}
 
 	return nil
 }
@@ -108,4 +137,42 @@ func (p *Player) Draw(screen *ebiten.Image) {
 		}
 	}
 	vector.DrawFilledRect(screen, float32(playerObject.Position.X), float32(float64(screen.Bounds().Dy())-constants.PlayerHeight)-float32(playerObject.Position.Y), float32(playerObject.Size.X), float32(playerObject.Size.Y), playerColor, false)
+}
+
+// ReconcileState reconciles the player state with the server state
+// by going back through the past client states and checking if it
+// the client state for that timestamp matches the server state.
+// If it doesn't match, the server state is applied and all of the
+// past updates that are after the last processed timestamp are replayed.
+func (p *Player) ReconcileState(state *gametypes.PlayerState) {
+	foundPreviousState := false
+	for i := len(p.previousStates) - 1; i >= 0; i-- {
+		ps := p.previousStates[i]
+		if ps.Timestamp == state.LastProcessedTimestamp {
+			foundPreviousState = true
+			if !ps.State.Equal(state) {
+				log.Warn("Reconciling player state at timestamp %d for %s", state.LastProcessedTimestamp, p.ID)
+				// apply the server state
+				p.State.Position.X = state.Position.X
+				p.State.Position.Y = state.Position.Y
+				p.State.Velocity.X = state.Velocity.X
+				p.State.Velocity.Y = state.Velocity.Y
+				p.State.IsOnGround = state.IsOnGround
+				p.State.Object.Position.X = state.Position.X
+				p.State.Object.Position.Y = state.Position.Y
+
+				// process all of the past updates that are after the last processed timestamp
+				for j := 0; j < len(p.pastUpdates); j++ {
+					if p.pastUpdates[j].Timestamp > state.LastProcessedTimestamp {
+						game.ApplyInput(p.State, p.pastUpdates[j])
+					}
+				}
+			}
+			break
+		}
+	}
+
+	if !foundPreviousState {
+		log.Warn("Failed to find previous state at timestamp %d for %s for reconciliation", state.LastProcessedTimestamp, p.ID)
+	}
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -235,7 +235,10 @@ func (g *Game) processPendingServerMessages() error {
 			}
 			g.lastGameStateReceived = gameState.Timestamp
 			g.gameStates = append(g.gameStates, gameState)
-			g.reconcilePlayerState(gameState)
+
+			if err := g.reconcilePlayerState(gameState); err != nil {
+				log.Warn("Failed to reconcile player state: %v", err)
+			}
 		case messages.MessageTypeServerPlayerConnect:
 			playerConnect := &messages.ServerPlayerConnect{}
 			if err := json.Unmarshal(message.Payload, playerConnect); err != nil {
@@ -307,9 +310,8 @@ func (g *Game) reconcilePlayerState(gameState *gametypes.GameState) error {
 	if !ok {
 		return fmt.Errorf("failed to cast game object %s to *objects.Player", playerObjectID)
 	}
-	playerObject.ReconcileState(playerState)
 
-	return nil
+	return playerObject.ReconcileState(playerState)
 }
 
 const (

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -213,19 +213,19 @@ func (gm *GameManager) processClientMessages(gameState *types.GameState) {
 				continue
 			}
 
+			// TODO: check for previousUpdates that have not been processed
 			// TODO: validate the update before applying it
-			log.Trace("Player %d initial position: %v, velocity: %v, isOnGround: %v", message.ClientID, gameState.Players[message.ClientID].Position, gameState.Players[message.ClientID].Velocity, gameState.Players[message.ClientID].IsOnGround)
-			UpdatePlayerState(gameState.Players[message.ClientID], clientPlayerUpdate)
+			ApplyInput(gameState.Players[message.ClientID], clientPlayerUpdate)
 		default:
 			log.Error("Unhandled message type: %s", message.Type)
 		}
 	}
 }
 
-// UpdatePlayerState updates the player's position and velocity based on the
+// ApplyInput updates the player's position and velocity based on the
 // client's input and the game state.
 // The player state is updated in place.
-func UpdatePlayerState(playerState *types.PlayerState, clientPlayerUpdate *messages.ClientPlayerUpdate) {
+func ApplyInput(playerState *types.PlayerState, clientPlayerUpdate *messages.ClientPlayerUpdate) {
 	// X-axis
 	// Apply input
 	dx := kinematic.Displacement(clientPlayerUpdate.InputX*constants.PlayerSpeed, clientPlayerUpdate.DeltaTime, 0)

--- a/pkg/game/types/types.go
+++ b/pkg/game/types/types.go
@@ -27,6 +27,25 @@ type Velocity struct {
 	Y float64 `json:"y"`
 }
 
+// Equal returns true if the player state is equal to the other player state
+func (p *PlayerState) Equal(other *PlayerState) bool {
+	return p.Position.X == other.Position.X &&
+		p.Position.Y == other.Position.Y &&
+		p.Velocity.X == other.Velocity.X &&
+		p.Velocity.Y == other.Velocity.Y &&
+		p.IsOnGround == other.IsOnGround
+}
+
+// Copy returns a copy of the player state with an empty object reference
+func (p *PlayerState) Copy() *PlayerState {
+	return &PlayerState{
+		LastProcessedTimestamp: p.LastProcessedTimestamp,
+		Position:               p.Position,
+		Velocity:               p.Velocity,
+		IsOnGround:             p.IsOnGround,
+	}
+}
+
 type ConnectPlayerEvent struct {
 	ClientID    uint32
 	PlayerState *PlayerState

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -8,7 +8,8 @@ import (
 
 const (
 	// MessageBufferSize represents the maximum size of a message
-	MessageBufferSize = 1024
+	// TODO: determine a more appropriate size
+	MessageBufferSize = 512
 )
 
 // Message types
@@ -35,6 +36,12 @@ type AssignID struct {
 	ClientID uint32 `json:"clientID"`
 }
 
+const (
+	// MaxPreviousUpdates is the maximum number of previous updates to send to the server
+	// TODO: determine a more appropriate size
+	MaxPreviousUpdates = 2
+)
+
 // TODO: change this to a more generic client input message
 // with a type field to differentiate between different input types (move, jump, fire, etc.)
 type ClientPlayerUpdate struct {
@@ -48,6 +55,9 @@ type ClientPlayerUpdate struct {
 	InputJump bool `json:"inputJump"`
 	// DeltaTime is the time since the last update as recorded by the client
 	DeltaTime float64 `json:"deltaTime"`
+	// PastUpdates is a list of past updates from the client to
+	// mitigate the effects of packet loss and out-of-order delivery
+	PastUpdates []*ClientPlayerUpdate `json:"previousUpdates"`
 }
 
 // ClientSyncTime is a message sent by the client to request a time sync with the server


### PR DESCRIPTION
Adds logic to reconcile past client states if the differ from received server states. If reconciliation is necessary, the server state is applied and all "future" client updates are re-applied.