### PR TITLE
remove game state reference from save worker

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,8 +60,8 @@ func main() {
 	authServer := auth.NewAuthServer(authServerOpts)
 	go authServer.Start()
 
-	clientManager := network.NewClientManager()
-	clientMessageQueue := queue.NewInMemoryQueue(10000)
+	connectionEventChan := make(chan network.ConnectionEvent, 100)
+	clientManager := network.NewClientManager(connectionEventChan)
 
 	firebaseProjectID := os.Getenv("FLYWHEEL_FIREBASE_PROJECT_ID")
 	if firebaseProjectID == "" {
@@ -72,6 +72,7 @@ func main() {
 		panic(fmt.Sprintf("Failed to create Firebase auth provider: %v", err))
 	}
 
+	clientMessageQueue := queue.NewInMemoryQueue(10000)
 	tcpServer := network.NewTCPServer(authProvider, clientManager, clientMessageQueue, *tcpPort)
 	udpServer := network.NewUDPServer(clientManager, clientMessageQueue, *udpPort)
 	go tcpServer.Start()
@@ -121,42 +122,34 @@ func main() {
 	go apiServer.Start()
 
 	serverEventQueue := queue.NewInMemoryQueue(1000)
-
 	connectionEventWorker := workers.NewConnectionEventWorker(workers.NewConnectionEventWorkerOptions{
-		ClientManager:    clientManager,
-		Repository:       repository,
-		ServerEventQueue: serverEventQueue,
+		ConnectionEventChan: connectionEventChan,
+		Repository:          repository,
+		ServerEventQueue:    serverEventQueue,
 	})
 	go connectionEventWorker.Start(ctx)
 
-	savePlayerStateChannelSize := 100
-	saveStateChan := make(chan workers.SaveStateRequest, savePlayerStateChannelSize)
-
+	saveStateChan := make(chan workers.SaveStateRequest, 100)
 	saveGameStateWorker := workers.NewSaveGameStateWorker(workers.NewSaveGameStateWorkerOptions{
 		Repository:    repository,
 		SaveStateChan: saveStateChan,
 	})
 	go saveGameStateWorker.Start(ctx)
 
-	serverMessageChannelSize := 100
-	serverMessageChan := make(chan workers.ServerMessage, serverMessageChannelSize)
-
+	serverMessageChan := make(chan workers.ServerMessage, 100)
 	serverMessageWorker := workers.NewServerMessageWorker(workers.NewServerMessageWorkerOptions{
 		ClientManager:     clientManager,
 		ServerMessageChan: serverMessageChan,
 	})
 	go serverMessageWorker.Start(ctx)
 
-	gameLoopInterval := 50 * time.Millisecond // 20 ticks per second
-	saveStateInterval := 5 * time.Second
 	gameManager := game.NewGameManager(game.NewGameManagerOptions{
 		ClientMessageQueue: clientMessageQueue,
 		ServerEventQueue:   serverEventQueue,
-		Repository:         repository,
 		SaveStateChan:      saveStateChan,
 		ServerMessageChan:  serverMessageChan,
-		GameLoopInterval:   gameLoopInterval,
-		SaveStateInterval:  saveStateInterval,
+		GameLoopInterval:   50 * time.Millisecond, // 20 ticks per second
+		SaveStateInterval:  5 * time.Second,
 	})
 
 	log.Info("Starting game manager")

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cbodonnell/flywheel/pkg/log"
 	"github.com/cbodonnell/flywheel/pkg/messages"
 	"github.com/cbodonnell/flywheel/pkg/queue"
-	"github.com/cbodonnell/flywheel/pkg/repositories"
 	"github.com/cbodonnell/flywheel/pkg/workers"
 	"github.com/solarlune/resolv"
 )
@@ -21,7 +20,6 @@ type GameManager struct {
 	gameState          *types.GameState
 	clientMessageQueue queue.Queue
 	serverEventQueue   queue.Queue
-	repository         repositories.Repository
 	saveStateChan      chan<- workers.SaveStateRequest
 	serverMessageChan  chan<- workers.ServerMessage
 	gameLoopInterval   time.Duration
@@ -32,7 +30,6 @@ type GameManager struct {
 type NewGameManagerOptions struct {
 	ClientMessageQueue queue.Queue
 	ServerEventQueue   queue.Queue
-	Repository         repositories.Repository
 	SaveStateChan      chan<- workers.SaveStateRequest
 	ServerMessageChan  chan<- workers.ServerMessage
 	GameLoopInterval   time.Duration
@@ -44,7 +41,6 @@ func NewGameManager(opts NewGameManagerOptions) *GameManager {
 		gameState:          types.NewGameState(NewCollisionSpace()),
 		clientMessageQueue: opts.ClientMessageQueue,
 		serverEventQueue:   opts.ServerEventQueue,
-		repository:         opts.Repository,
 		saveStateChan:      opts.SaveStateChan,
 		serverMessageChan:  opts.ServerMessageChan,
 		gameLoopInterval:   opts.GameLoopInterval,

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -18,35 +18,37 @@ import (
 )
 
 type GameManager struct {
-	clientMessageQueue  queue.Queue
-	serverEventQueue    queue.Queue
-	repository          repositories.Repository
-	gameState           *types.GameState
-	savePlayerStateChan chan<- workers.SavePlayerStateRequest
-	serverMessageChan   chan<- workers.ServerMessage
-	gameLoopInterval    time.Duration
+	gameState          *types.GameState
+	clientMessageQueue queue.Queue
+	serverEventQueue   queue.Queue
+	repository         repositories.Repository
+	saveStateChan      chan<- workers.SaveStateRequest
+	serverMessageChan  chan<- workers.ServerMessage
+	gameLoopInterval   time.Duration
+	saveStateInterval  time.Duration
 }
 
 // NewGameManagerOptions contains options for creating a new GameManager.
 type NewGameManagerOptions struct {
-	ClientMessageQueue  queue.Queue
-	ServerEventQueue    queue.Queue
-	Repository          repositories.Repository
-	GameState           *types.GameState
-	SavePlayerStateChan chan<- workers.SavePlayerStateRequest
-	ServerMessageChan   chan<- workers.ServerMessage
-	GameLoopInterval    time.Duration
+	ClientMessageQueue queue.Queue
+	ServerEventQueue   queue.Queue
+	Repository         repositories.Repository
+	SaveStateChan      chan<- workers.SaveStateRequest
+	ServerMessageChan  chan<- workers.ServerMessage
+	GameLoopInterval   time.Duration
+	SaveStateInterval  time.Duration
 }
 
 func NewGameManager(opts NewGameManagerOptions) *GameManager {
 	return &GameManager{
-		clientMessageQueue:  opts.ClientMessageQueue,
-		serverEventQueue:    opts.ServerEventQueue,
-		repository:          opts.Repository,
-		gameState:           opts.GameState,
-		savePlayerStateChan: opts.SavePlayerStateChan,
-		serverMessageChan:   opts.ServerMessageChan,
-		gameLoopInterval:    opts.GameLoopInterval,
+		gameState:          types.NewGameState(NewCollisionSpace()),
+		clientMessageQueue: opts.ClientMessageQueue,
+		serverEventQueue:   opts.ServerEventQueue,
+		repository:         opts.Repository,
+		saveStateChan:      opts.SaveStateChan,
+		serverMessageChan:  opts.ServerMessageChan,
+		gameLoopInterval:   opts.GameLoopInterval,
+		saveStateInterval:  opts.SaveStateInterval,
 	}
 }
 
@@ -56,14 +58,17 @@ func (gm *GameManager) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize game state: %v", err)
 	}
 
-	ticker := time.NewTicker(gm.gameLoopInterval)
-	defer ticker.Stop()
+	gameTicker := time.NewTicker(gm.gameLoopInterval)
+	defer gameTicker.Stop()
+
+	saveTicker := time.NewTicker(gm.saveStateInterval)
+	defer saveTicker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case t := <-ticker.C:
+		case t := <-gameTicker.C:
 			err := gm.gameTick(ctx, t)
 			if err != nil {
 				log.Error("Failed to run game tick: %v", err)
@@ -71,6 +76,13 @@ func (gm *GameManager) Start(ctx context.Context) error {
 			// TODO: server metrics
 			// duration := time.Since(t)
 			// log.Trace("Game tick took %s (%.2f%% of tick rate)", duration, float64(duration)/float64(gm.gameLoopInterval)*100)
+		case <-saveTicker.C:
+			saveRequest := workers.SaveStateRequest{
+				Timestamp: gm.gameState.Timestamp,
+				Type:      workers.SaveStateRequestTypeGame,
+				State:     gm.gameState.Copy(),
+			}
+			gm.saveStateChan <- saveRequest
 		}
 	}
 }
@@ -166,12 +178,12 @@ func (gm *GameManager) handleConnectPlayerEvent(event *types.ConnectPlayerEvent)
 
 func (gm *GameManager) handleDisconnectPlayerEvent(event *types.DisconnectPlayerEvent) error {
 	// send a request to save the player state before deleting it
-	saveRequest := workers.SavePlayerStateRequest{
-		Timestamp:   gm.gameState.Timestamp,
-		CharacterID: gm.gameState.Players[event.ClientID].CharacterID,
-		PlayerState: gm.gameState.Players[event.ClientID],
+	saveRequest := workers.SaveStateRequest{
+		Timestamp: gm.gameState.Timestamp,
+		Type:      workers.SaveStateRequestTypePlayer,
+		State:     gm.gameState.Players[event.ClientID].Copy(),
 	}
-	gm.savePlayerStateChan <- saveRequest
+	gm.saveStateChan <- saveRequest
 	// remove the player object from the collision space
 	gm.gameState.CollisionSpace.Remove(gm.gameState.Players[event.ClientID].Object)
 	// npc follow target cleanup

--- a/pkg/network/clients.go
+++ b/pkg/network/clients.go
@@ -49,21 +49,16 @@ type ClientManager struct {
 	clientsLock sync.RWMutex
 	// UDP connection for broadcasting to clients
 	udpConn             *net.UDPConn
-	connectionEventChan chan ConnectionEvent
+	connectionEventChan chan<- ConnectionEvent
 }
 
 // NewClientManager creates a new ClientManager
-func NewClientManager() *ClientManager {
+func NewClientManager(connectionEventChan chan<- ConnectionEvent) *ClientManager {
 	return &ClientManager{
 		clients:             make(map[uint32]*Client),
 		clientUIDs:          make(map[string]uint32),
-		connectionEventChan: make(chan ConnectionEvent, ConnectionEventChannelSize),
+		connectionEventChan: connectionEventChan,
 	}
-}
-
-// GetConnectionEventChan returns a one-way channel for receiving client events
-func (cm *ClientManager) GetConnectionEventChan() <-chan ConnectionEvent {
-	return cm.connectionEventChan
 }
 
 // SetUDPConn sets the UDP listener connection for all clients

--- a/pkg/workers/events.go
+++ b/pkg/workers/events.go
@@ -13,15 +13,15 @@ import (
 )
 
 type ConnectionEventWorker struct {
-	clientManager    *network.ClientManager
-	repository       repositories.Repository
-	serverEventQueue queue.Queue
+	connectionEventChan <-chan network.ConnectionEvent
+	repository          repositories.Repository
+	serverEventQueue    queue.Queue
 }
 
 type NewConnectionEventWorkerOptions struct {
-	ClientManager    *network.ClientManager
-	Repository       repositories.Repository
-	ServerEventQueue queue.Queue
+	ConnectionEventChan <-chan network.ConnectionEvent
+	Repository          repositories.Repository
+	ServerEventQueue    queue.Queue
 }
 
 // NewConnectionEventWorker creates a new ConnectionEventWorker.
@@ -29,9 +29,9 @@ type NewConnectionEventWorkerOptions struct {
 // and writes server events to a queue for the game loop to process.
 func NewConnectionEventWorker(opts NewConnectionEventWorkerOptions) *ConnectionEventWorker {
 	return &ConnectionEventWorker{
-		clientManager:    opts.ClientManager,
-		repository:       opts.Repository,
-		serverEventQueue: opts.ServerEventQueue,
+		connectionEventChan: opts.ConnectionEventChan,
+		repository:          opts.Repository,
+		serverEventQueue:    opts.ServerEventQueue,
 	}
 }
 
@@ -40,7 +40,7 @@ func (w *ConnectionEventWorker) Start(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case event := <-w.clientManager.GetConnectionEventChan():
+		case event := <-w.connectionEventChan:
 			switch event.Type {
 			case network.ConnectionEventTypeConnect:
 				w.handleClientConnect(event)

--- a/pkg/workers/save.go
+++ b/pkg/workers/save.go
@@ -2,7 +2,7 @@ package workers
 
 import (
 	"context"
-	"time"
+	"fmt"
 
 	"github.com/cbodonnell/flywheel/pkg/game/types"
 	"github.com/cbodonnell/flywheel/pkg/log"
@@ -10,64 +10,82 @@ import (
 )
 
 type SaveGameStateWorker struct {
-	repository          repositories.Repository
-	savePlayerStateChan <-chan SavePlayerStateRequest
-	gameState           *types.GameState
-	interval            time.Duration
+	repository    repositories.Repository
+	saveStateChan <-chan SaveStateRequest
 }
 
 type NewSaveGameStateWorkerOptions struct {
-	Repository          repositories.Repository
-	SavePlayerStateChan <-chan SavePlayerStateRequest
-	GameState           *types.GameState
-	Interval            time.Duration
+	Repository    repositories.Repository
+	SaveStateChan <-chan SaveStateRequest
 }
 
-type SavePlayerStateRequest struct {
-	Timestamp   int64
-	CharacterID int32
-	PlayerState *types.PlayerState
+type SaveStateRequest struct {
+	Timestamp int64
+	Type      SaveStateRequestType
+	State     interface{}
 }
+
+type SaveStateRequestType int
+
+const (
+	SaveStateRequestTypePlayer SaveStateRequestType = iota
+	SaveStateRequestTypeGame
+)
 
 // NewSaveGameStateWorker creates a new SaveGameStateWorker.
 // The worker processes save requests from the game loop and
 // periodically saves the game state to the repository.
 func NewSaveGameStateWorker(opts NewSaveGameStateWorkerOptions) *SaveGameStateWorker {
 	return &SaveGameStateWorker{
-		repository:          opts.Repository,
-		savePlayerStateChan: opts.SavePlayerStateChan,
-		gameState:           opts.GameState,
-		interval:            opts.Interval,
+		repository:    opts.Repository,
+		saveStateChan: opts.SaveStateChan,
 	}
 }
 
 func (w *SaveGameStateWorker) Start(ctx context.Context) {
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
-
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case saveRequest := <-w.savePlayerStateChan:
-			w.savePlayerState(ctx, saveRequest)
-		case <-ticker.C:
-			gameState := w.gameState.Copy()
-			w.saveGameState(ctx, gameState)
+		case saveRequest := <-w.saveStateChan:
+			switch saveRequest.Type {
+			case SaveStateRequestTypePlayer:
+				if err := w.savePlayerState(ctx, saveRequest); err != nil {
+					log.Error("Failed to save player state: %v", err)
+				}
+			case SaveStateRequestTypeGame:
+				if err := w.saveGameState(ctx, saveRequest); err != nil {
+					log.Error("Failed to save game state: %v", err)
+				}
+			}
 		}
 	}
 }
 
-func (w *SaveGameStateWorker) savePlayerState(ctx context.Context, saveRequest SavePlayerStateRequest) {
-	err := w.repository.SavePlayerState(ctx, saveRequest.Timestamp, saveRequest.CharacterID, saveRequest.PlayerState)
-	if err != nil {
-		log.Error("Failed to save player state: %v", err)
+func (w *SaveGameStateWorker) savePlayerState(ctx context.Context, saveRequest SaveStateRequest) error {
+	playerState, ok := saveRequest.State.(*types.PlayerState)
+	if !ok {
+		return fmt.Errorf("failed to cast player state")
 	}
+
+	err := w.repository.SavePlayerState(ctx, saveRequest.Timestamp, playerState.CharacterID, playerState)
+	if err != nil {
+		return fmt.Errorf("failed to save player state: %v", err)
+	}
+
+	return nil
 }
 
-func (w *SaveGameStateWorker) saveGameState(ctx context.Context, gameState *types.GameState) {
+func (w *SaveGameStateWorker) saveGameState(ctx context.Context, saveRequest SaveStateRequest) error {
+	gameState, ok := saveRequest.State.(*types.GameState)
+	if !ok {
+		return fmt.Errorf("failed to cast game state")
+	}
+
 	err := w.repository.SaveGameState(ctx, gameState)
 	if err != nil {
-		log.Error("Failed to save game state: %v", err)
+		return fmt.Errorf("failed to save game state: %v", err)
 	}
+
+	return nil
 }


### PR DESCRIPTION
Removes the game state dependency for the save worker. All save requests are initiated by the game manager and copies of the desired game state are passed as events to the worker.